### PR TITLE
Update code generation slides date

### DIFF
--- a/conferences/code-generation/index-en.html
+++ b/conferences/code-generation/index-en.html
@@ -385,7 +385,7 @@
 
         <div style="margin-bottom:1em;display:flex;gap:0.5em;flex-wrap:wrap;">
             <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">GitHub Copilot</span>
-            <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">May 21, 2026</span>
+            <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">May 28, 2026</span>
         </div>
 
         <h1 style="color:#fff;font-size:1.85em;font-weight:800;line-height:1.15;margin:0 0 0.5em;">
@@ -742,7 +742,7 @@ Here are the specifications:
 - tickets are GitHub tickets, as discovered with the MCP prompt from the previous demo
 - add/edit/remove tickets with a title, GitHub repository, link and status
 - store them in a database, and initialize the database with the tickets from the previous command
-- it has have a fancy UI with Vue.js</pre>
+- it has a fancy UI with Vue.js</pre>
             <button class="copy-btn" type="button"
                     onclick="copyPrompt(this, 'demo-prompt-skill')"
                     aria-label="Copy the prompt"
@@ -1079,7 +1079,7 @@ Here are the specifications:
         </div>
         <div class="terminal-body">
             <span class="terminal-prompt">&gt;</span>
-            <span id="demo-prompt-app-1" class="terminal-text">Transform the UI to be entreprise-like.</span>
+            <span id="demo-prompt-app-1" class="terminal-text">Transform the UI to be enterprise-like.</span>
             <button class="copy-btn" type="button"
                     onclick="copyPrompt(this, 'demo-prompt-app-1')"
                     aria-label="Copy the prompt">

--- a/conferences/code-generation/index-fr.html
+++ b/conferences/code-generation/index-fr.html
@@ -385,7 +385,7 @@
 
         <div style="margin-bottom:1em;display:flex;gap:0.5em;flex-wrap:wrap;">
             <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">GitHub Copilot</span>
-            <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">21 mai 2026</span>
+            <span style="background:rgba(255,255,255,.18);border:1px solid rgba(255,255,255,.35);border-radius:20px;padding:4px 14px;font-size:0.5em;color:#fff;">28 mai 2026</span>
         </div>
 
         <h1 style="color:#fff;font-size:1.85em;font-weight:800;line-height:1.15;margin:0 0 0.5em;">
@@ -743,7 +743,7 @@ Here are the specifications:
 - tickets are GitHub tickets, as discovered with the MCP prompt from the previous demo
 - add/edit/remove tickets with a title, GitHub repository, link and status
 - store them in a database, and initialize the database with the tickets from the previous command
-- it has have a fancy UI with Vue.js</pre>
+- it has a fancy UI with Vue.js</pre>
             <button class="copy-btn" type="button"
                     onclick="copyPrompt(this, 'demo-prompt-skill')"
                     aria-label="Copier le prompt"
@@ -1080,7 +1080,7 @@ Here are the specifications:
         </div>
         <div class="terminal-body">
             <span class="terminal-prompt">&gt;</span>
-            <span id="demo-prompt-app-1" class="terminal-text">Transform the UI to be entreprise-like.</span>
+            <span id="demo-prompt-app-1" class="terminal-text">Transform the UI to be enterprise-like.</span>
             <button class="copy-btn" type="button"
                     onclick="copyPrompt(this, 'demo-prompt-app-1')"
                     aria-label="Copier le prompt">


### PR DESCRIPTION
Updates the code-generation slide decks for the May 28, 2026 talk so the English and French versions stay aligned. Also fixes two shared demo prompt typos that appear in both decks.

Validation: not run. The local Ruby/Bundler setup does not match Gemfile.lock: Bundler 2.5.3 is unavailable under the active system Ruby 2.6.