### PR TITLE
Temporarily hide credits & prize slide from Copilot keynote

### DIFF
--- a/conferences/copilot-app/index-en.html
+++ b/conferences/copilot-app/index-en.html
@@ -676,7 +676,9 @@
 
 <!-- ══════════════════════════════════════════════════════════════
      SLIDE 12 — GET STARTED: CREDITS & PRIZE  (generic placeholders)
+     TEMPORARILY HIDDEN — uncomment the <section> below to restore.
 ══════════════════════════════════════════════════════════════ -->
+<!-- HIDDEN-SLIDE-12-START
 <section data-background="linear-gradient(150deg,#1e40af 0%,#2563eb 55%,#3b82f6 100%)">
     <h2 style="color:#fff;border-color:rgba(255,255,255,.25);">Get started — and win 🏆</h2>
 
@@ -705,6 +707,7 @@
         🌐 julien-dubois.com &nbsp;&nbsp; 𝕏 @juliendubois &nbsp;&nbsp; 🐙 github.com/jdubois
     </div>
 </section>
+HIDDEN-SLIDE-12-END -->
 
 </div><!-- /.slides -->
 </div><!-- /.reveal -->


### PR DESCRIPTION
## Why

Following up on the merged keynote deck (#14). The credits & prize slide uses placeholder content that isn't finalized yet, so I'm hiding it until the event details are confirmed.

## What

Comments out slide 12 (credits/prize) in `conferences/copilot-app/index-en.html` so the deck ends cleanly on the playbook slide. The slide is wrapped in `HIDDEN-SLIDE-12-START`/`HIDDEN-SLIDE-12-END` markers so it can be restored in a single edit once the real credit amount and prize details are available.