### PR TITLE
Fix Conferences page: cache-busting + collapsible talk polish

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
 
         <!-- Bootstrap 5 CSS -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-        <link rel="stylesheet" href="/css/main.css">
+        <link rel="stylesheet" href="/css/main.css?v={{ site.github.build_revision | default: site.time | date: '%s' }}">
     </head>
     <body>
         <!-- Bootstrap 5 Navbar -->
@@ -84,7 +84,7 @@
         <!-- Bootstrap 5 JS Bundle (includes Popper) - No jQuery needed -->
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
-        <script src="/js/main.js"></script>
+        <script src="/js/main.js?v={{ site.github.build_revision | default: site.time | date: '%s' }}"></script>
 
         <!-- Google tag (gtag.js) -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-92TRR0HJMQ"></script>

--- a/conferences.html
+++ b/conferences.html
@@ -29,9 +29,13 @@ title: Conferences
 
             <details class="talk">
                 <summary>
-                    <h2>From coder to manager of agents</h2>
+                    <h3>From coder to manager of agents</h3>
                     <p>
                         At a hackathon, the winner isn't whoever types fastest &mdash; it's whoever ships the most. This talk shows how to flip from writing every line yourself to managing a fleet of GitHub Copilot agents that build in parallel while you sleep, and how to out-ship the room because of it.
+                    </p>
+                    <p class="talk-slides">Slides:
+                        <a href="/conferences/winning-the-hackathon/index-en.html" target="_blank">English</a>
+                        <a href="/conferences/winning-the-hackathon/index-fr.html" target="_blank">French</a>
                     </p>
                 </summary>
                 <div class="talk-body">
@@ -48,20 +52,18 @@ title: Conferences
                     <p>
                         Language-agnostic and demo-driven: the playbook applies whatever your stack. Expect concrete, opinionated advice from really shipping with parallel AI agents.
                     </p>
-
-                    <h3>Slides</h3>
-                    <ul>
-                        <li><a href="/conferences/winning-the-hackathon/index-en.html" target="_blank">English version</a></li>
-                        <li><a href="/conferences/winning-the-hackathon/index-fr.html" target="_blank">French version</a></li>
-                    </ul>
                 </div>
             </details>
 
             <details class="talk">
                 <summary>
-                    <h2>AI code generation in Java</h2>
+                    <h3>AI code generation in Java</h3>
                     <p>
                         Generative AI has transformed software development. In just a few years, we've moved from basic code completion to fully autonomous coding agents that read your project, write code, run tests, and fix their own mistakes.
+                    </p>
+                    <p class="talk-slides">Slides:
+                        <a href="/conferences/code-generation/index-en.html" target="_blank">English</a>
+                        <a href="/conferences/code-generation/index-fr.html" target="_blank">French</a>
                     </p>
                 </summary>
                 <div class="talk-body">
@@ -76,12 +78,6 @@ title: Conferences
                     <p>
                         Expect plenty of live demos and concrete, opinionated advice drawn from real-world experience building and shipping with AI agents.
                     </p>
-
-                    <h3>Slides</h3>
-                    <ul>
-                        <li><a href="/conferences/code-generation/index-en.html" target="_blank">English version</a></li>
-                        <li><a href="/conferences/code-generation/index-fr.html" target="_blank">French version</a></li>
-                    </ul>
                 </div>
             </details>
 

--- a/css/main.css
+++ b/css/main.css
@@ -343,17 +343,28 @@ ul li {
     outline-offset: 2px;
 }
 
-.talk > summary h2 {
+.talk > summary h3 {
     margin: 0 0 0.5rem;
     transition: color 0.3s ease;
 }
 
-.talk > summary:hover h2 {
+.talk > summary:hover h3 {
     color: var(--primary-color);
 }
 
 .talk > summary p:last-child {
     margin-bottom: 0;
+}
+
+.talk-slides {
+    margin-top: 1rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.talk-slides a {
+    margin-left: 0.85rem;
 }
 
 /* Chevron indicator */


### PR DESCRIPTION
## Why

Two things, prompted by the live `/conferences` page where the new collapsible talks "showed up correctly on the preview but not on the web page".

### 1. Stale-asset bug (the real cause of the live issue)
The live HTML and CSS were actually deployed correctly — but `/css/main.css` and `/js/main.js` were linked with **no cache-busting**, and GitHub Pages serves them with `cache-control: max-age=600`. So returning visitors kept the *old* CSS for up to 10 minutes after a deploy, meaning the new collapsible-talk styles didn't apply until the cache expired.

**Fix:** assets now carry `?v={{ site.github.build_revision | default: site.time | date: '%s' }}` (the commit SHA on GitHub Pages, build time locally). Every deploy gets a unique URL, so this never recurs.

### 2. Conferences page polish (from an `/impeccable critique`, scored 34/40)
- **Heading outline (P1):** talk titles were `<h2>`, competing with the page's section headers (*Contact me*, *Videos*, *Workshops*…). Demoted to `<h3>` so they sit under *Current talks* — correct document outline and screen-reader navigation.
- **Surfaced the CTA (P2):** the EN/FR slide links were buried inside the collapsed body. They're now shown as a `Slides: English · French` line in the collapsed summary, so the decks (the primary call to action) are reachable without expanding. Removed the now-duplicate Slides list from the expanded body.
- CSS: retargeted the `.talk` summary heading rule to `h3` and added a small `.talk-slides` style (reuses existing tokens, no inline styles).

## Verification
- `bundle exec jekyll build` clean.
- Heading outline confirmed: sections `h2`, talk titles `h3`.
- Screenshotted collapsed + expanded states at desktop; no horizontal overflow at 320/360/375px.
- Detector (`impeccable`) clean on `conferences.html`.

No changes to `/_site/` (generated).