### PR TITLE
Add website links to BootUI, Dr JSkill, and Coffilot projects

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -40,6 +40,7 @@ description: "Projects by Julien Dubois — the Open Source frameworks and devel
                 Dr JSkill builds on my JHipster experience to scaffold Spring Boot 4.x projects with Java 25, a database, REST APIs, and your choice of front-end. Unlike JHipster it is an AI agent: easier to tune, more versatile, and able to update existing projects. It is currently an experiment.
             </p>
             <p class="talk-links">Links:
+                <a href="https://www.julien-dubois.com/dr-jskill/" target="_blank">Website</a>
                 <a href="https://github.com/jdubois/dr-jskill" target="_blank">GitHub</a>
             </p>
         </div>
@@ -57,6 +58,7 @@ description: "Projects by Julien Dubois — the Open Source frameworks and devel
                 BootUI gives Spring Boot developers immediate runtime visibility &mdash; health, memory, threads, startup timing, HTTP exchanges, and logs &mdash; plus dedicated advisors for JVM tuning, security, Hibernate, and GraalVM readiness, all behind a local-first safety model.
             </p>
             <p class="talk-links">Links:
+                <a href="https://www.julien-dubois.com/boot-ui/" target="_blank">Website</a>
                 <a href="https://github.com/jdubois/boot-ui" target="_blank">GitHub</a>
             </p>
         </div>
@@ -74,6 +76,7 @@ description: "Projects by Julien Dubois — the Open Source frameworks and devel
                 Coffilot lets you build, test, package, and run your Java app from the Copilot side panel, with a graphical test view, a &ldquo;run affected&rdquo; mode, live JVM metrics, and advisor scans that push fixes straight back to the agent.
             </p>
             <p class="talk-links">Links:
+                <a href="https://www.julien-dubois.com/coffilot/" target="_blank">Website</a>
                 <a href="https://github.com/jdubois/coffilot" target="_blank">GitHub</a>
             </p>
         </div>


### PR DESCRIPTION
On the projects page, BootUI, Dr JSkill, and Coffilot only linked to their GitHub repos. Each of these also has a dedicated web page, so visitors had no direct path to the product sites from this page.

This adds a **Website** link before the existing **GitHub** link for each of the three projects, mirroring how the JHipster entry already surfaces its website. URLs are taken from each repo's homepage metadata and were verified to return HTTP 200 over HTTPS:

- Dr JSkill: https://www.julien-dubois.com/dr-jskill/
- BootUI: https://www.julien-dubois.com/boot-ui/
- Coffilot: https://www.julien-dubois.com/coffilot/

The markup reuses the existing `.talk-links` pattern with `target="_blank"` (which adds the external-link icon via CSS), and the existing `margin-left` rule spaces the two links automatically, so no CSS changes were needed.