### PR TITLE
Add missing GitHub link to JHipster on projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -24,6 +24,7 @@ description: "Projects by Julien Dubois — the Open Source frameworks and devel
             </p>
             <p class="talk-links">Links:
                 <a href="https://www.jhipster.tech/" target="_blank">Website</a>
+                <a href="https://github.com/jhipster/generator-jhipster" target="_blank">GitHub</a>
             </p>
         </div>
     </details>


### PR DESCRIPTION
On the Projects page, JHipster was the only project whose links list had just a Website link, while every other project (Dr JSkill, BootUI, Coffilot, LangChain4j, Spring AI) also exposed a GitHub link.

This adds a GitHub link to JHipster pointing at its flagship `jhipster/generator-jhipster` repository (the 22,000+ stars repo referenced in the description). The target repo mirrors how LangChain4j and Spring AI link to their main repository rather than the org page, keeping the links consistent across all projects.